### PR TITLE
Code refactoring

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@
 #   languagepackspath => 'C:\\source\\LanguagePacks',
 #   sppath => 'C:\\source\\sharepoint.exe',
 #   spversion  => 'Foundation',
-#   setupaccountpassword  => 'P@ssw0rd',
+#   setup_account_password  => 'P@ssw0rd',
 #   spfarmaccount => 's-spfarm',
 #   dbserver => 'SQL_ALIAS',
 #   dbaliasinstance => 'localhost',
@@ -51,7 +51,8 @@ class windows_sharepoint
   $key                                       = '',
   $offline                                   = false,
   $autoadminlogon                            = true,
-  $setupaccountpassword                      = '',
+  $setup_account_password                    = '',
+  $setup_account_username                    = 'Administrator',
   $disableloopbackcheck                      = true,
   $disableunusedservices                     = true,
   $disableieenhancedsecurity                 = true,
@@ -67,12 +68,12 @@ class windows_sharepoint
   $centraladminport                          = 4242,
   $centraladminssl                           = false,
   
-  $dbserver                                  = 'SQL_ALIAS',                  # name of alias, or name of SQL Server
+  $dbserver                                  = 'SQL_ALIAS',        # name of alias, or name of SQL Server
   $dbalias                                   = true,
-  $dbaliasport                               = '',                  # if empty default will used
-  $dbaliasinstance                           = '',                  # name of SQL Server
+  $dbaliasport                               = '',                 # if empty default will used
+  $dbaliasinstance                           = '',                 # name of SQL Server
   
-  $dbprefix                                  = 'SP2013',            # Prefix for DB
+  $dbprefix                                  = 'SP2013',           # Prefix for DB
   $dbuser                                    = '',
   $dbpassword                                = '',
   $configdb                                  = 'ConfigDB',
@@ -146,6 +147,14 @@ class windows_sharepoint
     spversion         => $spversion,
   }
 
+  class{"windows_sharepoint::stage_bin":
+    basepath          => $basepath,
+    languagepackspath => $languagepackspath,
+    updatespath       => $updatespath,
+    sppath            => $sppath,
+    spversion         => $spversion,
+  }
+
   class{"windows_sharepoint::install":
   ## XML input file
     xmlinputfile                              => $xmlinputfile,
@@ -155,7 +164,8 @@ class windows_sharepoint
     key                                       => $key,
     offline                                   => $offline,
     autoadminlogon                            => $autoadminlogon,
-    setupaccountpassword                      => $setupaccountpassword,
+    setup_account_password                    => $setup_account_password,
+    setup_account_username                    => $setup_account_username,
     disableloopbackcheck                      => $disableloopbackcheck,
     disableunusedservices                     => $disableunusedservices,
     disableieenhancedsecurity                 => $disableieenhancedsecurity,
@@ -240,5 +250,9 @@ class windows_sharepoint
     spversion                                 => $spversion,
     computername                              => $computername,
   }
-  anchor{'windows_sharepoint::begin':} -> Class["windows_sharepoint::prepsp"] -> Class["windows_sharepoint::install"] -> anchor{'windows_sharepoint::end':}
+  anchor{'windows_sharepoint::begin':} ->
+  Class['windows_sharepoint::prepsp'] ->
+  Class['windows_sharepoint::stage_bin'] ->
+  Class['windows_sharepoint::install'] ->
+  anchor{'windows_sharepoint::end':}
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,119 +1,103 @@
-# == Class: windows_sharepoint
-#
-# Full description of class windows_sharepoint here.
-#
-# === Parameters
-#
-# === Examples
-#
-#
-# === Authors
-#
-# Author Name <author@domain.com>
-#
-# === Copyright
-#
-# Copyright 2014 Your name here, unless otherwise noted.
-#
+# == Class: windows_sharepoint::install
 class windows_sharepoint::install 
 (
-  $ensure  = present,
+  $ensure                                  = present,
   ## XML input file
-  $xmlinputfile                              = hiera('windows_sharepoint::xmlinputfile', ''),               # if specify all other options will be desactivated
-  $basepath                                  = hiera('windows_sharepoint::basepath', 'C:\\'),
-  $userxml                                   = hiera('windows_sharepoint::userxml', 'C:\users.xml'),
+  $xmlinputfile                            = hiera('windows_sharepoint::xmlinputfile', ''),                      # if specify all other options will be desactivated
+  $basepath                                = hiera('windows_sharepoint::basepath', 'C:\\'),
+  $userxml                                 = hiera('windows_sharepoint::userxml', 'C:\users.xml'),
   ## Install parameters
-  $key                                       = hiera('windows_sharepoint::key', ''),
-  $offline                                   = hiera('windows_sharepoint::offline', false),
-  $autoadminlogon                            = hiera('windows_sharepoint::autoadminlogon', true),
-  $setup_account_username                    = hiera('windows_sharepoint::setup_account_username', ''),
-  $setup_account_password                    = hiera('windows_sharepoint::setup_account_password', ''),
-  $disableloopbackcheck                      = hiera('windows_sharepoint::disableloopbackcheck', true),
-  $disableunusedservices                     = hiera('windows_sharepoint::disableunusedservices', true),
-  $disableieenhancedsecurity                 = hiera('windows_sharepoint::disableieenhancedsecurity', true),
-  $certificaterevocationlistcheck            = hiera('windows_sharepoint::certificaterevocationlistcheck', true),
+  $key                                     = hiera('windows_sharepoint::key', ''),
+  $offline                                 = hiera('windows_sharepoint::offline', false),
+  $autoadminlogon                          = hiera('windows_sharepoint::autoadminlogon', true),
+  $setup_account_username                  = hiera('windows_sharepoint::setup_account_username', ''),
+  $setup_account_password                  = hiera('windows_sharepoint::setup_account_password', ''),
+  $disableloopbackcheck                    = hiera('windows_sharepoint::disableloopbackcheck', true),
+  $disableunusedservices                   = hiera('windows_sharepoint::disableunusedservices', true),
+  $disableieenhancedsecurity               = hiera('windows_sharepoint::disableieenhancedsecurity', true),
+  $certificaterevocationlistcheck          = hiera('windows_sharepoint::certificaterevocationlistcheck', true),
   
   ## Farm parameters
-  $passphrase                                = hiera('windows_sharepoint::passphrase', ''),
-  $spfarmaccount                             = hiera('windows_sharepoint::spfarmaccount', ''),
-  $spfarmpassword                            = hiera('windows_sharepoint::spfarmpassword', ''),                 # if empty will check XML File
+  $passphrase                              = hiera('windows_sharepoint::passphrase', ''),
+  $spfarmaccount                           = hiera('windows_sharepoint::spfarmaccount', ''),
+  $spfarmpassword                          = hiera('windows_sharepoint::spfarmpassword', ''),                    # if empty will check XML File
   
-  $centraladminprovision                     = hiera('windows_sharepoint::centraladminprovision', 'localhost'),       #where to provision
-  $centraladmindatabase                      = hiera('windows_sharepoint::centraladmindatabase', 'Content_Admin'),
-  $centraladminport                          = hiera('windows_sharepoint::centraladminport', 4242),
-  $centraladminssl                           = hiera('windows_sharepoint::centraladminssl', false),
+  $centraladminprovision                   = hiera('windows_sharepoint::centraladminprovision', 'localhost'),    #where to provision
+  $centraladmindatabase                    = hiera('windows_sharepoint::centraladmindatabase', 'Content_Admin'),
+  $centraladminport                        = hiera('windows_sharepoint::centraladminport', 4242),
+  $centraladminssl                         = hiera('windows_sharepoint::centraladminssl', false),
   
-  $dbserver                                  = hiera('windows_sharepoint::dbserver', 'localhost'),                  # name of alias, or name of SQL Server
-  $dbalias                                   = hiera('windows_sharepoint::dbalias', false),
-  $dbaliasport                               = hiera('windows_sharepoint::dbaliasport', 1433),                  # if empty default will used
-  $dbaliasinstance                           = hiera('windows_sharepoint::dbaliasinstance', 'MSSQLSERVER'),                  # name of SQL Server
+  $dbserver                                = hiera('windows_sharepoint::dbserver', 'localhost'),                 # name of alias, or name of SQL Server
+  $dbalias                                 = hiera('windows_sharepoint::dbalias', false),
+  $dbaliasport                             = hiera('windows_sharepoint::dbaliasport', 1433),                     # if empty default will used
+  $dbaliasinstance                         = hiera('windows_sharepoint::dbaliasinstance', 'MSSQLSERVER'),        # name of SQL Server
   
-  $dbprefix                                  = hiera('windows_sharepoint::dbprefix', 'SP2013'),            # Prefix for DB
-  $dbuser                                    = hiera('windows_sharepoint::dbuser', ''),
-  $dbpassword                                = hiera('windows_sharepoint::dbpassword', ''),
-  $configdb                                  = hiera('windows_sharepoint::configdb', 'ConfigDB'),
+  $dbprefix                                = hiera('windows_sharepoint::dbprefix', 'SP2013'),                    # Prefix for DB
+  $dbuser                                  = hiera('windows_sharepoint::dbuser', ''),
+  $dbpassword                              = hiera('windows_sharepoint::dbpassword', ''),
+  $configdb                                = hiera('windows_sharepoint::configdb', 'ConfigDB'),
   
   ## Services part
-  $sanboxedcodeservicestart                  = hiera('windows_sharepoint::sanboxedcodeservicestart', false),
-  $claimstowindowstokenserverstart           = hiera('windows_sharepoint::claimstowindowstokenserverstart', false),
-  $claimstowindowstokenserverupdateaccount   = hiera('windows_sharepoint::claimstowindowstokenserverupdateaccount', false),
+  $sanboxedcodeservicestart                = hiera('windows_sharepoint::sanboxedcodeservicestart', false),
+  $claimstowindowstokenserverstart         = hiera('windows_sharepoint::claimstowindowstokenserverstart', false),
+  $claimstowindowstokenserverupdateaccount = hiera('windows_sharepoint::claimstowindowstokenserverupdateaccount', false),
   
-  $smtpinstall                               = hiera('windows_sharepoint::smtpinstall', false),
-  $smtpoutgoingemailconfigure                = hiera('windows_sharepoint::smtpoutgoingemailconfigure', false),
-  $smtpoutgoingserver                        = hiera('windows_sharepoint::smtpoutgoingserver', ''),
-  $smtpoutgoingemailaddress                  = hiera('windows_sharepoint::smtpoutgoingemailaddress', ''),
-  $smtpoutgoingreplytoemail                  = hiera('windows_sharepoint::smtpoutgoingreplytoemail', ''),
+  $smtpinstall                             = hiera('windows_sharepoint::smtpinstall', false),
+  $smtpoutgoingemailconfigure              = hiera('windows_sharepoint::smtpoutgoingemailconfigure', false),
+  $smtpoutgoingserver                      = hiera('windows_sharepoint::smtpoutgoingserver', ''),
+  $smtpoutgoingemailaddress                = hiera('windows_sharepoint::smtpoutgoingemailaddress', ''),
+  $smtpoutgoingreplytoemail                = hiera('windows_sharepoint::smtpoutgoingreplytoemail', ''),
 
-  $incomingemailstart                        = hiera('windows_sharepoint::incomingemailstart', 'localhost'),
-  $distributedcachestart                     = hiera('windows_sharepoint::distributedcachestart', 'localhost'),
-  $workflowtimerstart                        = hiera('windows_sharepoint::workflowtimerstart', 'localhost'),
-  $foundationwebapplicationstart             = hiera('windows_sharepoint::foundationwebapplicationstart', 'localhost'),
+  $incomingemailstart                      = hiera('windows_sharepoint::incomingemailstart', 'localhost'),
+  $distributedcachestart                   = hiera('windows_sharepoint::distributedcachestart', 'localhost'),
+  $workflowtimerstart                      = hiera('windows_sharepoint::workflowtimerstart', 'localhost'),
+  $foundationwebapplicationstart           = hiera('windows_sharepoint::foundationwebapplicationstart', 'localhost'),
 
-  $spapppoolaccount                          = hiera('windows_sharepoint::spapppoolaccount', ''),
-  $spapppoolpassword                         = hiera('windows_sharepoint::spapppoolpassword', ''),                 # if empty will check XML File
-  $spservicesaccount                         = hiera('windows_sharepoint::spservicesaccount', ''),
-  $spservicespassword                        = hiera('windows_sharepoint::spservicespassword', ''),                 # if empty will check XML File
-  $spsearchaccount                           = hiera('windows_sharepoint::spsearchaccount', ''),
-  $spsearchpassword                          = hiera('windows_sharepoint::spsearchpassword', ''),                 # if empty will check XML File
-  $spsuperreaderaccount                      = hiera('windows_sharepoint::spsuperreaderaccount', ''),
-  $spsuperuseraccount                        = hiera('windows_sharepoint::spsuperuseraccount', ''),
-  $spcrawlaccount                            = hiera('windows_sharepoint::spcrawlaccount', ''),
-  $spcrawlpassword                           = hiera('windows_sharepoint::spcrawlpassword', ''),                 # if empty will check XML File
-  $spsyncaccount                             = hiera('windows_sharepoint::spsyncaccount', ''),
-  $spsyncpassword                            = hiera('windows_sharepoint::spsyncpassword', ''),                # if empty will check XML File
-  $spusrprfaccount                           = hiera('windows_sharepoint::spusrprfaccount', ''),
-  $spusrprfpassword                          = hiera('windows_sharepoint::spusrprfpassword', ''),                # if empty will check XML File
-  $spexcelaccount                            = hiera('windows_sharepoint::spexcelaccount', ''),
-  $spexcelpassword                           = hiera('windows_sharepoint::spexcelpassword', ''),                # if empty will check XML File
+  $spapppoolaccount                        = hiera('windows_sharepoint::spapppoolaccount', ''),
+  $spapppoolpassword                       = hiera('windows_sharepoint::spapppoolpassword', ''),                 # if empty will check XML File
+  $spservicesaccount                       = hiera('windows_sharepoint::spservicesaccount', ''),
+  $spservicespassword                      = hiera('windows_sharepoint::spservicespassword', ''),                # if empty will check XML File
+  $spsearchaccount                         = hiera('windows_sharepoint::spsearchaccount', ''),
+  $spsearchpassword                        = hiera('windows_sharepoint::spsearchpassword', ''),                  # if empty will check XML File
+  $spsuperreaderaccount                    = hiera('windows_sharepoint::spsuperreaderaccount', ''),
+  $spsuperuseraccount                      = hiera('windows_sharepoint::spsuperuseraccount', ''),
+  $spcrawlaccount                          = hiera('windows_sharepoint::spcrawlaccount', ''),
+  $spcrawlpassword                         = hiera('windows_sharepoint::spcrawlpassword', ''),                   # if empty will check XML File
+  $spsyncaccount                           = hiera('windows_sharepoint::spsyncaccount', ''),
+  $spsyncpassword                          = hiera('windows_sharepoint::spsyncpassword', ''),                    # if empty will check XML File
+  $spusrprfaccount                         = hiera('windows_sharepoint::spusrprfaccount', ''),
+  $spusrprfpassword                        = hiera('windows_sharepoint::spusrprfpassword', ''),                  # if empty will check XML File
+  $spexcelaccount                          = hiera('windows_sharepoint::spexcelaccount', ''),
+  $spexcelpassword                         = hiera('windows_sharepoint::spexcelpassword', ''),                   # if empty will check XML File
 
   ## Log
-  $logcompress                               = hiera('windows_sharepoint::logcompress', true),
-  $iislogspath                               = hiera('windows_sharepoint::iislogspath', 'C:\SPLOGS\IIS'),
-  $ulslogspath                               = hiera('windows_sharepoint::ulslogspath', 'C:\SPLOGS\ULS'),
-  $usagelogspath                             = hiera('windows_sharepoint::usagelogspath', 'C:\SPLOGS\USAGE'),
+  $logcompress                             = hiera('windows_sharepoint::logcompress', true),
+  $iislogspath                             = hiera('windows_sharepoint::iislogspath', 'C:\SPLOGS\IIS'),
+  $ulslogspath                             = hiera('windows_sharepoint::ulslogspath', 'C:\SPLOGS\ULS'),
+  $usagelogspath                           = hiera('windows_sharepoint::usagelogspath', 'C:\SPLOGS\USAGE'),
   
   ###DefaultWebApp
-  $removedefaultwebapp                       = hiera('windows_sharepoint::removedefaultwebapp', false),             # if true the default web app will be removed.
-  $webappurl                                 = hiera('windows_sharepoint::webappurl', 'https://localhost'),
-  $applicationPool                           = hiera('windows_sharepoint::applicationPool', 'SharePointDefault_App_Pool'),
-  $webappname                                = hiera('windows_sharepoint::webappname', 'SharePoint Default Web App'),
-  $webappport                                = hiera('windows_sharepoint::webappport', 443),
-  $webappdatabasename                        = hiera('windows_sharepoint::webappdatabasename', 'Content_SharePointDefault'),
+  $removedefaultwebapp                     = hiera('windows_sharepoint::removedefaultwebapp', false),            # if true the default web app will be removed.
+  $webappurl                               = hiera('windows_sharepoint::webappurl', 'https://localhost'),
+  $applicationPool                         = hiera('windows_sharepoint::applicationPool', 'SharePointDefault_App_Pool'),
+  $webappname                              = hiera('windows_sharepoint::webappname', 'SharePoint Default Web App'),
+  $webappport                              = hiera('windows_sharepoint::webappport', 443),
+  $webappdatabasename                      = hiera('windows_sharepoint::webappdatabasename', 'Content_SharePointDefault'),
   
   ##DefaultSiteCol
-  $siteurl                                   = hiera('windows_sharepoint::siteurl', 'https://localhost'),
-  $sitecolname                               = hiera('windows_sharepoint::sitecolname', 'WebSite'),
-  $sitecoltemplate                           = hiera('windows_sharepoint::sitecoltemplate', 'STS#0'),
-  $sitecoltime24                             = hiera('windows_sharepoint::sitecoltime24', true),
-  $sitecollcid                               = hiera('windows_sharepoint::sitecollcid', 1033),
-  $sitecollocale                             = hiera('windows_sharepoint::sitecollocale', 'en-us'),
-  $sitecolowner                              = hiera('windows_sharepoint::sitecolowner', ''),
+  $siteurl                                 = hiera('windows_sharepoint::siteurl', 'https://localhost'),
+  $sitecolname                             = hiera('windows_sharepoint::sitecolname', 'WebSite'),
+  $sitecoltemplate                         = hiera('windows_sharepoint::sitecoltemplate', 'STS#0'),
+  $sitecoltime24                           = hiera('windows_sharepoint::sitecoltime24', true),
+  $sitecollcid                             = hiera('windows_sharepoint::sitecollcid', 1033),
+  $sitecollocale                           = hiera('windows_sharepoint::sitecollocale', 'en-us'),
+  $sitecolowner                            = hiera('windows_sharepoint::sitecolowner', ''),
   
-  $mysitehost                                = hiera('windows_sharepoint::mysitehost', ''),
-  $mysitemanagedpath                         = hiera('windows_sharepoint::mysitemanagedpath', 'personal'),
+  $mysitehost                              = hiera('windows_sharepoint::mysitehost', ''),
+  $mysitemanagedpath                       = hiera('windows_sharepoint::mysitemanagedpath', 'personal'),
   
-  $spversion                                 = hiera('windows_sharepoint::spversion', 'Foundation'),
-  $computername                              = hiera('windows_sharepoint::computername', $::hostname),
+  $spversion                               = hiera('windows_sharepoint::spversion', 'Foundation'),
+  $computername                            = hiera('windows_sharepoint::computername', $::hostname),
 )
 {
   if(!empty($xmlinputfile)){ # Install with xml file
@@ -125,37 +109,37 @@ class windows_sharepoint::install
       notice("using $spversion")
     }
     if((empty($spfarmaccount) or empty($spapppoolaccount) or empty($spservicesaccount) or empty($spsearchaccount) or empty($spcrawlaccount) or empty($spsuperreaderaccount) or empty($spsuperuseraccount)) and $spversion == 'Foundation'){
-       fail('All Accounts need to be specify (spfarmaccount, spapppoolaccount, spservicesaccount, spsearchaccount, spcrawlaccount, spsuperreaderaccount, spsuperuseraccount)')
+       fail('All Accounts need to be specified (spfarmaccount, spapppoolaccount, spservicesaccount, spsearchaccount, spcrawlaccount, spsuperreaderaccount, and spsuperuseraccount).')
     }
 
     if((empty($spfarmaccount) or empty($spapppoolaccount) or empty($spservicesaccount) or empty($spsearchaccount) or empty($spcrawlaccount) or empty($spsuperreaderaccount) or empty($spsuperuseraccount) or empty($spsyncaccount) or empty($spusrprfaccount)) and $spversion == 'Standard'){
-       fail('All Accounts need to be specify except spexcelaccount')
+       fail('All Accounts need to be specified except spexcelaccount.')
     }
 
     if((empty($spfarmaccount) or empty($spapppoolaccount) or empty($spservicesaccount) or empty($spsearchaccount) or empty($spcrawlaccount) or empty($spsuperreaderaccount) or empty($spsuperuseraccount) or empty($spsyncaccount) or empty($spusrprfaccount) or empty($spexcelaccount)) and $spversion == 'Enterprise'){
-       fail('All Accounts need to be specify')
+       fail('All Accounts need to be specified.')
     }
 
     if($autoadminlogon == true and empty(setup_account_password)){
-      fail('If autoadminlogin is set to true you need to specify your setup password')
+      fail('If autoadminlogin is set to true you need to specify your setup password.')
     }
     if(empty($dbserver)){
       fail('DBServer is mandatory')
     }
     if($dbalias == true and empty(dbaliasinstance)){
-      fail('Can\'t set DBalias to true without specify a dbaliasinstance')
+      fail('Can\'t set DBalias to true without specifying a dbaliasinstance.')
     }
     if(empty($sitecolowner)){
-      fail('Site Col Owner can\'t be empty')
+      fail('sitecolowner can\'t be empty.')
     }
     if(empty(key)){
-      fail('A serial number (key) is mandatory')
+      fail('A serial number (key) is mandatory.')
     }
     if(empty(passphrase)){
-      fail('PassPhrase is empty')
+      fail('PassPhrase is empty.')
     }
     if($centraladminport < 1023 or $centraladminport > 32767 or $centraladminport == 443 or centraladmindatabase == 80){
-      fail('centraladminport can\'t be set to this value. CentralAdminPort need to be superior at 1023, inferior at 32767 and different of 443 and 80')
+      fail('centraladminport can\'t be set to this value. CentralAdminPort need to be greater than 1023, less than 32767 and not equal to 443 or 80.')
     }
 
     file{"$basepath\\Puppet-SharePoint\\generatexml.ps1":
@@ -411,8 +395,6 @@ if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true) { \
       Exec['lauching_auto_sp_installer'] ~>
       Exec['SetCentralAdmin Port']
     }
-
-    # Exec['lauching_auto_sp_installer'] ~> Exec['trigger_reboot_for_sp_install']
 
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,8 @@ class windows_sharepoint::install
   $key                                       = hiera('windows_sharepoint::key', ''),
   $offline                                   = hiera('windows_sharepoint::offline', false),
   $autoadminlogon                            = hiera('windows_sharepoint::autoadminlogon', true),
-  $setupaccountpassword                      = hiera('windows_sharepoint::setupaccountpassword', ''),
+  $setup_account_username                    = hiera('windows_sharepoint::setup_account_username', ''),
+  $setup_account_password                    = hiera('windows_sharepoint::setup_account_password', ''),
   $disableloopbackcheck                      = hiera('windows_sharepoint::disableloopbackcheck', true),
   $disableunusedservices                     = hiera('windows_sharepoint::disableunusedservices', true),
   $disableieenhancedsecurity                 = hiera('windows_sharepoint::disableieenhancedsecurity', true),
@@ -42,10 +43,10 @@ class windows_sharepoint::install
   $centraladminport                          = hiera('windows_sharepoint::centraladminport', 4242),
   $centraladminssl                           = hiera('windows_sharepoint::centraladminssl', false),
   
-  $dbserver                                  = hiera('windows_sharepoint::dbserver', 'SQL_ALIAS'),                  # name of alias, or name of SQL Server
-  $dbalias                                   = hiera('windows_sharepoint::dbalias', true),
-  $dbaliasport                               = hiera('windows_sharepoint::dbaliasport', ''),                  # if empty default will used
-  $dbaliasinstance                           = hiera('windows_sharepoint::dbaliasinstance', ''),                  # name of SQL Server
+  $dbserver                                  = hiera('windows_sharepoint::dbserver', 'localhost'),                  # name of alias, or name of SQL Server
+  $dbalias                                   = hiera('windows_sharepoint::dbalias', false),
+  $dbaliasport                               = hiera('windows_sharepoint::dbaliasport', 1433),                  # if empty default will used
+  $dbaliasinstance                           = hiera('windows_sharepoint::dbaliasinstance', 'MSSQLSERVER'),                  # name of SQL Server
   
   $dbprefix                                  = hiera('windows_sharepoint::dbprefix', 'SP2013'),            # Prefix for DB
   $dbuser                                    = hiera('windows_sharepoint::dbuser', ''),
@@ -135,7 +136,7 @@ class windows_sharepoint::install
        fail('All Accounts need to be specify')
     }
 
-    if($autoadminlogon == true and empty(setupaccountpassword)){
+    if($autoadminlogon == true and empty(setup_account_password)){
       fail('If autoadminlogin is set to true you need to specify your setup password')
     }
     if(empty($dbserver)){
@@ -156,46 +157,240 @@ class windows_sharepoint::install
     if($centraladminport < 1023 or $centraladminport > 32767 or $centraladminport == 443 or centraladmindatabase == 80){
       fail('centraladminport can\'t be set to this value. CentralAdminPort need to be superior at 1023, inferior at 32767 and different of 443 and 80')
     }
+
     file{"$basepath\\Puppet-SharePoint\\generatexml.ps1":
       content => template('windows_sharepoint/autospinstaller.erb'),
       replace => yes,
     }
-    exec{"Generate XML":
-      provider => powershell,
-      command  => "$basepath\\Puppet-SharePoint\\generatexml.ps1",
-      require  => File["$basepath\\Puppet-SharePoint\\generatexml.ps1"],
-      onlyif   => "if ((test-path '${basepath}\\Puppet-SharePoint\\xmlgenerated') -eq \$true){exit 1;}",
+
+    # logoutput false so we don't display passwords
+    exec{'generate_xml':
+      provider  => powershell,
+      command   => "\
+\$ErrorActionPreference = 'Stop'; \
+$basepath\\Puppet-SharePoint\\generatexml.ps1",
+      require   => File["$basepath\\Puppet-SharePoint\\generatexml.ps1"],
+      onlyif    => "if ((test-path '${basepath}\\Puppet-SharePoint\\xmlgenerated') -eq \$true){exit 1;}; ",
+      logoutput => false,
     }
+
+    $reboot_check = " \
+\$ErrorActionPreference = \"Stop\"; \
+\$results = \$false; \
+\$results = test-path \"C:\\windows\\windows_sharepoint_puppet_reboot.txt\"; \
+if (\$results -eq \$true) { \
+ exit 0; \
+ } else { \
+ exit 1; \
+};"
+
+    # Note: Can't use $ErrorActionPreference = 'Stop' because Puppet will throw
+    #   a Ruby parse error.
+    $cmd_launch_installer = " \
+\$password = ConvertTo-SecureString '${setup_account_password}' -AsPlainText -Force; \
+\$cred= New-Object System.Management.Automation.PSCredential (\"${setup_account_username}\", \$password); \
+\$install_proc = Start-Process \"\$pshome\\powershell.exe\" \
+ -Credential \$cred \
+ -Wait \
+ -WorkingDirectory '${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\' \
+ -ArgumentList ' \
+  -ExecutionPolicy Bypass \
+  .\\AutoSPInstallerMain.ps1 \
+  -inputFile \"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml\" \
+  -unattended '\
+ -PassThru \
+ -RedirectStandardOutput \"C:\\puppet-sharepoint\\install.log\"; \
+if(\$install_proc.exitcode -ne 0) {Throw}; "
+
+    $base_check_cmd = " \
+if ((Test-Path C:\\Windows\\windows_sharepoint_puppet_reboot.txt) -eq \$true) { \
+ \$skip_checks = \$true; \
+} else { \
+ \$skip_checks = \$false; \
+ Add-PSSnapin 'Microsoft.SharePoint.PowerShell'; \
+ \$snapin = Get-PSSnapin '*SharePoint.PowerShell'; \
+ if(\$snapin.count -eq 0) { \
+  \$check_failed = \$true; \
+ } else { \
+  \$check_failed = \$false; \
+ }
+} ;"
+
+    $cmd_check_sp_state_service = " \
+if(!\$skip_checks) { \
+ \$test_prop = \$null; \
+ \$test_prop = Get-SPStateServiceApplication; \
+ if(\$test_prop -eq \$null){ \
+   \$check_failed = \$true; \
+ } \
+} ;"
+
+    $cmd_excel_service_check = " \
+if(!\$skip_checks) { \
+ \$test_prop = \$null; \
+ \$test_prop = Get-SPExcelServiceApplication | ?{ \
+  \$_.DisplayName -Match \"Excel Services \" \
+ }; \
+if(\$test_prop -eq \$null) { \
+  \$check_failed = \$true; \
+ }\
+} ; "
+
+    $cmd_check_sp_profile_service = " \
+if(!\$skip_checks) { \
+ \$test_prop = \$null; \
+ \$test_prop = Get-SPStateServiceApplication | ?{ \
+  \$_.DisplayName -Match \"User Profile \" \
+ }; \
+ if(\$test_prop -eq \$null){ \
+   \$check_failed = \$true; \
+ } \
+}; "
+
+    $cmd_cleanup_reg_and_exit = " \
+\$ErrorActionPreference = 'Stop'; \
+if(!\$skip_checks) { \
+ if(\$check_failed) { \
+  exit 1; \
+  Throw \"Verify failed.\"; \
+ } else { \
+  New-ItemProperty \
+   -Path \"HKLM:\\Software\\AutoSPInstaller\\\" \
+   -Name 'PuppetSharePointInstallInProgress' \
+   -Value 0 \
+   -PropertyType 'String' \
+   -Force | Out-Null; \
+  exit 0; \
+ }\
+}; "
+
+    $sp_foundation_install_unless_cmd = " \
+${base_check_cmd} \
+${cmd_check_sp_state_service} \
+${cmd_cleanup_reg_and_exit}; "
+
+    $sp_standard_install_unless_cmd = " \
+${base_check_cmd} \
+${cmd_check_sp_profile_service} \
+${cmd_cleanup_reg_and_exit}; "
+
+    $sp_ent_install_unless_cmd = " \
+${base_check_cmd} \
+${cmd_excel_service_check} \
+${cmd_cleanup_reg_and_exit}; "
+
+    exec{'trigger_reboot_for_sp_install':
+      provider  => 'powershell',
+      command   => "write-host \"Triggering reboot.\";",
+      onlyif    => $reboot_check,
+      logoutput => true,
+      notify    => Reboot['after_auto_sp_install'],
+    }
+
+    reboot{'after_auto_sp_install':
+      when => 'refreshed',
+    }
+
+    $sp_foundation_install_cmd = " \
+${cmd_launch_installer} \
+${sp_foundation_install_unless_cmd}"
+
+    $sp_standard_install_cmd = "\
+${cmd_launch_installer} \
+${sp_standard_install_unless_cmd}"
+
+    $sp_ent_install_cmd = " \
+${cmd_launch_installer} \
+${sp_ent_install_unless_cmd}"
 
     if($spversion == 'Foundation'){
-
-      exec{"Lauching AutoSPInstaller":
-        provider => powershell,
-        command  => "New-Item -Path \"HKLM:\\Software\\\" -Name 'AutoSPInstaller' -Force | Out-Null;New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 1 -PropertyType 'String' -Force | Out-Null;\$password = ConvertTo-SecureString '${setupaccountpassword}' -AsPlainText -Force; \$cred= New-Object System.Management.Automation.PSCredential (\"\$env:userdomain\\Administrator\", \$password);Start-Process \"\$pshome\\powershell.exe\" -Credential \$cred -Wait -WorkingDirectory '${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\' -ArgumentList '-ExecutionPolicy Bypass .\\AutoSPInstallerMain.ps1 -inputFile \"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml\" -unattended' -ea SilentlyContinue;Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getSPStateServiceApplication = Get-SPStateServiceApplication;if(\$getSPStateServiceApplication -ne \$null){New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;}}",
-        timeout  => "7200",
-        onlyif   => "if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true){if((Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\" -ErrorAction SilentlyContinue).PuppetSharePointInstallInProgress -eq '1'){Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getSPStateServiceApplication = Get-SPStateServiceApplication;if(\$getSPStateServiceApplication -eq \$null){exit 0;}else{New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;exit 1;}}else{exit 0;}}else{Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){exit 1;}else{exit 0;}}}" 
-      }
+      $final_install_cmd = $sp_foundation_install_cmd
+      $final_install_unless_cmd = $sp_foundation_install_unless_cmd
     }elsif($spversion == 'Standard'){
-      exec{"Lauching AutoSPInstaller":
-        provider => powershell,
-        command  => "New-Item -Path \"HKLM:\\Software\\\" -Name 'AutoSPInstaller' -Force | Out-Null;New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 1 -PropertyType 'String' -Force | Out-Null;\$password = ConvertTo-SecureString '${setupaccountpassword}' -AsPlainText -Force; \$cred= New-Object System.Management.Automation.PSCredential (\"\$env:userdomain\\Administrator\", \$password);Start-Process \"\$pshome\\powershell.exe\" -Credential \$cred -Wait -WorkingDirectory '${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\' -ArgumentList '-ExecutionPolicy Bypass .\\AutoSPInstallerMain.ps1 -inputFile \"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml\" -unattended' -ea SilentlyContinue;Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getSPUPS = Get-SPServiceApplication | ?{\$_.DisplayName -Match \"User Profile \"};if(\$getSPUPS -ne \$null){New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;}}",
-        timeout  => "7200",
-        onlyif   => "if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true){if((Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\" -ErrorAction SilentlyContinue).PuppetSharePointInstallInProgress -eq '1'){Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getSPUPS = Get-SPServiceApplication | ?{\$_.DisplayName -Match \"User Profile \"};if(\$getSPUPS -eq \$null){exit 0;}else{New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;exit 1;}}else{exit 0;}}else{Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){exit 1;}else{exit 0;}}}" 
-      }
+      $final_install_cmd = $sp_standard_install_cmd
+      $final_install_unless_cmd = $sp_standard_install_unless_cmd
     }elsif($spversion == 'Enterprise'){
-      exec{"Lauching AutoSPInstaller":
-        provider => powershell,
-        command  => "New-Item -Path \"HKLM:\\Software\\\" -Name 'AutoSPInstaller' -Force | Out-Null;New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 1 -PropertyType 'String' -Force | Out-Null;\$password = ConvertTo-SecureString '${setupaccountpassword}' -AsPlainText -Force; \$cred= New-Object System.Management.Automation.PSCredential (\"\$env:userdomain\\Administrator\", \$password);Start-Process \"\$pshome\\powershell.exe\" -Credential \$cred -Wait -WorkingDirectory '${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\' -ArgumentList '-ExecutionPolicy Bypass .\\AutoSPInstallerMain.ps1 -inputFile \"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml\" -unattended' -ea SilentlyContinue;Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getExcel = Get-SPExcelServiceApplication | ?{\$_.DisplayName -Match \"Excel Services \"};if(\$getExcel -ne \$null){New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;}}",
-        timeout  => "7200",
-        onlyif   => "if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true){if((Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\" -ErrorAction SilentlyContinue).PuppetSharePointInstallInProgress -eq '1'){Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getExcel = Get-SPExcelServiceApplication | ?{\$_.DisplayName -Match \"Excel Services \"};if(\$getExcel -eq \$null){exit 0;}else{New-ItemProperty -Path \"HKLM:\\Software\\AutoSPInstaller\\\" -Name 'PuppetSharePointInstallInProgress' -Value 0 -PropertyType 'String' -Force | Out-Null;exit 1;}}else{exit 0;}}else{Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ErrorAction SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){exit 1;}else{exit 0;}}}" 
-      }
+      $final_install_cmd  = $sp_ent_install_cmd
+      $final_install_unless_cmd = $sp_ent_install_unless_cmd
     }
-    
-    exec{"SetCentralAdmin Port":
+
+    file{'C:\windows\windows_sharepoint_puppet_reboot.txt':
+      ensure => 'absent',
+    } ->
+    exec {'fake_out_sp_setup_dotnet_ver':
+      provider  => 'powershell',
+      command   => " \
+\$ErrorActionPreference = 'Stop'; \
+\$reg_path = \"HKLM:\\software\\microsoft\\NET Framework Setup\\NDP\\v4\\Client\"; \
+\$reg_path_simple = \"HKEY_LOCAL_MACHINE\\software\\microsoft\\NET Framework Setup\\NDP\\v4\\Client\"; \
+setacl.exe \
+ -ot reg \
+ -on \"\$reg_path_simple\" \
+ -actn setowner \
+ -ownr \"n:Administrators\" | out-null; \
+setacl.exe \
+ -ot reg \
+ -on \"\$reg_path_simple\" \
+ -actn setowner \
+ -ownr \"n:Administrators\" \
+ -actn ace \
+ -ace \"n:Administrators;p:full\" | out-null; \
+\$curVer = (Get-ItemProperty \$reg_path).Version; \
+if(\$curVer -ne \"4.5.50501\") { \
+ \$curVer | out-file 'C:\\windows\\cur_dotnet_ver.txt' -Force; \
+ New-ItemProperty -path \$reg_path -Name \"Version\" -Value \"4.5.50501\" -Force; \
+}; ",
+      logoutput => true,
+    } ->
+    notify{'Calling AutoSpInstaller.':} ->
+    exec{'lauching_auto_sp_installer':
       provider => powershell,
-      command  => "Add-PSSnapin Microsoft.SharePoint.PowerShell -ea SilentlyContinue;Set-SPCentralAdministration -Port ${centraladminport} -Confirm:\$false",
-      onlyif   => "if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true){if((Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\" -ErrorAction SilentlyContinue).PuppetSharePointInstallInProgress -eq '1'){exit 1;}else{Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ea SilentlyContinue;\$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue;if(\$snapin.count -eq 1){\$getSPStateServiceApplication = Get-SPStateServiceApplication;if(\$getSPStateServiceApplication -eq \$null){exit 1;}else{\$port = [Microsoft.SharePoint.Administration.SPAdministrationWebApplication]::Local.Sites.VirtualServer.Port;if(\$port -eq ${centraladminport}){exit 1;}}}else{exit 1;}}}else{\$port = [Microsoft.SharePoint.Administration.SPAdministrationWebApplication]::Local.Sites.VirtualServer.Port;if(\$port -eq ${centraladminport}){exit 1;}}",
+      command  => $final_install_cmd,
+      timeout  => "7200",
+      unless   => $final_install_unless_cmd,
+      before   => Exec['trigger_reboot_for_sp_install'],
+    } ->
+    exec {'fix_sp_setup_dotnet_ver':
+      provider => 'powershell',
+      command  => " \
+\$reg_path = \"HKLM:\\software\\microsoft\\NET Framework Setup\\NDP\\v4\\Client\"; \
+\$reg_path_simple = \"HKEY_LOCAL_MACHINE\\software\\microsoft\\NET Framework Setup\\NDP\\v4\\Client\"; \
+\$orig_ver = gc 'C:\\Windows\\cur_dotnet_ver.txt' -Force; \
+\$curVer = \$reg_path.Version; \
+if(\$curVer -ne \$orig_ver) { \
+﻿New-ItemProperty -path \$reg_path -Name \"Version\" -Value \$orig_ver -Force; \
+}; "
     }
+
+    exec{'SetCentralAdmin Port':
+      provider => powershell,
+      command  => " \
+\$ErrorActionPreference = 'Stop'; \
+Add-PSSnapin Microsoft.SharePoint.PowerShell -ea SilentlyContinue;\
+Set-SPCentralAdministration -Port ${centraladminport} -Confirm:\$false",
+      onlyif   => "\
+if((test-path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\") -eq \$true) { \
+ if((Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\AutoSPInstaller\\\" -ErrorAction SilentlyContinue).PuppetSharePointInstallInProgress -eq '1') {\
+  exit 1;\
+ } else {\
+  Add-PSSnapin 'Microsoft.SharePoint.PowerShell' -ea SilentlyContinue; \
+  \$snapin = Get-PSSnapin '*SharePoint.PowerShell' -ea SilentlyContinue; \
+  if(\$snapin.count -eq 1){ \
+   \$getSPStateServiceApplication = Get-SPStateServiceApplication; \
+   if(\$getSPStateServiceApplication -eq \$null){ \
+    exit 1; \
+   } else { \
+    \$port = [Microsoft.SharePoint.Administration.SPAdministrationWebApplication]::Local.Sites.VirtualServer.Port; \
+    if(\$port -eq ${centraladminport}){exit 1;} \
+   } \
+  } else {exit 1;} \
+ } else { \
+  \$port = [Microsoft.SharePoint.Administration.SPAdministrationWebApplication]::Local.Sites.VirtualServer.Port;\
+  if(\$port -eq ${centraladminport}){exit 1;}\
+ } \
+}",
+    }
+
     if($removedefaultwebapp){
       windows_sharepoint::webapplication{"default - $webappname":
         url                    => "${webappurl}",
@@ -205,10 +400,19 @@ class windows_sharepoint::install
         applicationpoolaccount => "${spapppoolaccount}",
         ensure                 => absent,
       }
-      Exec["Generate XML"] -> Exec["Lauching AutoSPInstaller"] -> Exec["SetCentralAdmin Port"] -> Windows_sharepoint::Webapplication ["default - $webappname"]
-    }else{
-      Exec["Generate XML"] -> Exec["Lauching AutoSPInstaller"] -> Exec["SetCentralAdmin Port"]
+
+      Exec['generate_xml'] ~>
+      Exec['Lauching AutoSPInstaller'] ~>
+      Exec['SetCentralAdmin Port'] ~>
+      Windows_sharepoint::Webapplication["default - $webappname"]
+
+    } else {
+      Exec['generate_xml'] ~>
+      Exec['lauching_auto_sp_installer'] ~>
+      Exec['SetCentralAdmin Port']
     }
+
+    # Exec['lauching_auto_sp_installer'] ~> Exec['trigger_reboot_for_sp_install']
 
   }
 }

--- a/manifests/prepsp.pp
+++ b/manifests/prepsp.pp
@@ -8,120 +8,68 @@ class windows_sharepoint::prepsp(
   $updatespath       = $updatespath,
   $sppath            = $sppath,
   $spversion         = $spversion,
-){
+) {
   validate_re($spversion, '^(Foundation|Standard|Enterprise)$', 'valid values for mode are \'Foundation\' or \'Standard\' or \'Enterprise\'')
   if(empty($sppath)){
     fail('You need to specify the sharepoint installation path')
   }
-  if(!defined(File["${basepath}\\Puppet-SharePoint\\"])){
-    file{["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"]:
-      ensure => "directory",
-    }
-  }
-  if(!empty($languagepackspath)){
-    exec{'copy language packs':
-      command => "\$lps = get-item '${languagepackspath}\\*';\$base = '$basepath\\Puppet-SharePoint\\2013\\LanguagePacks';foreach(\$lp in \$lps){\$destination = \$base + '\\' + \$lp.Name;\$source = \$lp.FullName + '/*';if((test-path \$destination) -eq \$false){New-Item -Path \$base -Name \$lp.Name -type Directory;Copy-Item -Path \$source -Destination \$destination -Force -Recurse;}}",
-      provider => "powershell",
-      onlyif   => "\$lps = get-item '${languagepackspath}\\*';if(\$lps -ne \$null){\$base = '$basepath\\Puppet-SharePoint\\2013\\LanguagePacks';\$exist='false';foreach(\$lp in \$lps){\$destination = \$base + '\\' + \$lp.Name;\$source = \$lp.FullName + '/*';if((test-path \$destination) -eq \$true){\$exist = 'true'}}if(\$exist -eq 'true'){exit 1;}}else{exit 1;}",
-      timeout  => "600",
-    }
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerFunctions.ps1",
-    source_permissions => ignore,
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerMain.ps1",
-    source_permissions => ignore,
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerLaunch.bat",
-    source_permissions => ignore,
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerInput.xml",
-    source_permissions => ignore,
-    replace            => false,
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerFunctionsCustom.ps1",
-    source_permissions => ignore,
-  }
-  file{"${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerConfigureRemoteTarget.ps1":
-    source => "puppet:///modules/windows_sharepoint/scripts/AutoSPInstallerConfigureRemoteTarget.ps1",
-    source_permissions => ignore,
+
+  $new_base_path = "${basepath}\\Puppet-SharePoint"
+  file{ $new_base_path:
+    ensure => 'directory',
   }
 
-  if(!empty($updatespath)){
-    exec{'copy updates':
-      command => "\$source = '${updatespath}\\*';\$destination = '${basepath}\\Puppet-SharePoint\\2013\\Updates';Copy-Item -Path \$source -Destination \$destination -Force -Recurse;",
-      provider => "powershell",
-      onlyif   => "\$lps = get-item '${updatespath}\\*';if(\$lps -ne \$null){\$base = '${basepath}\\Puppet-SharePoint\\2013\\Updates';\$exist='false';foreach(\$lp in \$lps){\$destination = \$base + '\\' +\$lp.Name;if((test-path \$destination) -eq \$true){\$exist = 'true'; }}if(\$exist -eq 'true'){exit 1;}}else{exit 1;}",
-      timeout  => "600",
-    }
-  }
-  if($spversion == 'Foundation'){
-    exec{'extract SP':
-      command => "Start-Process '${sppath}' -ArgumentList '/extract:C:/Puppet-SharePoint/2013/SharePoint /q' -Wait",
-      provider => "powershell",
-      onlyif   => "if((test-path '${basepath}\\Puppet-SharePoint\\2013\\SharePoint\\setup.exe') -eq \$true){exit 1}",
-      timeout  => "600",
-    }
-  }elsif($spversion == 'Standard' or $spversion == 'Enterprise'){
-    windows_isos{'SPStandard':
-      ensure   => present,
-      isopath  => $sppath,
-      xmlpath  => "${basepath}\\Puppet-SharePoint\\isos.xml",
-    } -> 
-    file{"$basepath\\Puppet-SharePoint\\spcopy.ps1":
-      content => template('windows_sharepoint/prepsp-server.erb'),
-    } ->
-    exec{'extract SP':
-      command => "$basepath\\Puppet-SharePoint\\spcopy.ps1;",
-      provider => "powershell",
-      onlyif   => "if((test-path '${basepath}\\Puppet-SharePoint\\2013\\SharePoint\\setup.exe') -eq \$true){exit 1}",
-      timeout  => "600",
+  if(!empty($languagepackspath)){
+    exec{'copy_language_packs':
+      command => " \
+\$lps = get-item '${languagepackspath}\\*'; \
+\$base = '${new_base_path}\\2013\\LanguagePacks'; \
+foreach(\$lp in \$lps){ \
+ \$destination = \$base + '\\' + \$lp.Name; \
+ \$source = \$lp.FullName + '/*'; \
+ if((test-path \$destination) -eq \$false){ \
+  New-Item -Path \$base -Name \$lp.Name -type Directory; \
+  Copy-Item -Path \$source -Destination \$destination -Force -Recurse; \
+ } \
+}",
+      provider => 'powershell',
+      onlyif   => " \
+\$lps = get-item '${languagepackspath}\\*'; \
+if(\$lps -ne \$null){ \
+ \$base = '${new_base_path}\\2013\\LanguagePacks'; \
+ \$exist='false';\
+ foreach(\$lp in \$lps){ \
+  \$destination = \$base + '\\' + \$lp.Name; \
+  \$source = \$lp.FullName + '/*'; \
+  if((test-path \$destination) -eq \$true){\$exist = 'true'} \
+ }; \
+ if(\$exist -eq 'true'){exit 1;} \
+} else {exit 1;}",
+      timeout  => '600',
     }
   }
   
-  if(!empty($languagepackspath)){
-    if(!empty($updatespath) and $spversion == 'Foundation'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy language packs'] -> Exec['copy updates'] -> Exec['extract SP']
-    }elsif(!empty($updatespath) and $spversion == 'Standard'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy language packs'] -> Exec['copy updates'] -> Windows_isos["SPStandard"]
-    }elsif(!empty($updatespath) and $spversion == 'Enterprise'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"]  -> Exec['copy language packs']
-    }elsif(empty($updatespath) and $spversion == 'Foundation'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"]  -> Exec['copy language packs'] -> Exec['extract SP']
-    }elsif(empty($updatespath) and $spversion == 'Standard'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"]  -> Exec['copy language packs'] -> Windows_isos["SPStandard"]
-    }elsif(empty($updatespath) and $spversion == 'Enterprise'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"]  -> Exec['copy language packs']
+  if(!empty($updatespath)){
+    exec{'copy_updates':
+      command => "\
+\$source = '${updatespath}\\*'; \
+\$destination = '${new_base_path}\\2013\\Updates'; \
+Copy-Item -Path \$source -Destination \$destination -Force -Recurse;",
+      provider => "powershell",
+      onlyif   => "\
+\$lps = get-item '${updatespath}\\*'; \
+if(\$lps -ne \$null){\$base = '${new_base_path}\\2013\\Updates'; \
+\$exist='false';foreach(\$lp in \$lps){ \
+ \$destination = \$base + '\\' +\$lp.Name; \
+ if((test-path \$destination) -eq \$true){\$exist = 'true'; }}; \
+ if(\$exist -eq 'true'){exit 1;} \
+} else {exit 1;}",
+      timeout  => "600",
     }
   }
-  elsif(!empty($updatespath)){
-    if(!empty($languagepackspath) and $spversion == 'Foundation'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy language packs'] -> Exec['copy updates'] -> Exec['extract SP']
-    }elsif(!empty($languagepackspath) and $spversion == 'Standard'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy language packs'] -> Exec['copy updates'] -> Windows_isos["SPStandard"]
-    }elsif(!empty($languagepackspath) and $spversion == 'Enterprise'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy language packs'] -> Exec['copy updates']
-    }elsif(empty($languagepackspath) and $spversion == 'Foundation'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy updates'] -> Exec['extract SP']
-    }elsif(empty($languagepackspath) and $spversion == 'Standard'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy updates'] -> Windows_isos["SPStandard"]
-    }elsif(empty($languagepackspath) and $spversion == 'Enterprise'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['copy updates']
-    }
-  }else{
-    if($spversion == 'Foundation'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] -> Exec['extract SP']
-    }
-    elsif($spversion == 'Standard'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"] ->  Windows_isos["SPStandard"]
-    }
-    elsif($spversion == 'Enterprise'){
-      File["$basepath\\Puppet-SharePoint","$basepath\\Puppet-SharePoint\\AutoSPInstaller","$basepath\\Puppet-SharePoint\\2013","$basepath\\Puppet-SharePoint\\2013\\Updates","$basepath\\Puppet-SharePoint\\2013\\SharePoint","$basepath\\Puppet-SharePoint\\2013\\LanguagePacks"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctionsCustom.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerFunctions.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerMain.ps1"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerLaunch.bat"] -> File["${basepath}\\Puppet-SharePoint\\AutoSPInstaller\\AutoSPInstallerInput.xml"]
-    }
+
+  if(!empty($languagepackspath) and !empty($updatespath)) {
+    Exec['copy_language_packs'] ~> Exec['copy_updates']
   }
+
 }

--- a/manifests/stage_bin.pp
+++ b/manifests/stage_bin.pp
@@ -1,0 +1,39 @@
+##
+# This class stages sharepoint binaries.
+#
+##
+class windows_sharepoint::stage_bin(
+  $basepath          = $basepath,
+  $languagepackspath = $languagepackspath,
+  $updatespath       = $updatespath,
+  $sppath            = $sppath,
+  $spversion         = $spversion,
+) {
+
+  if($spversion == 'Foundation') {
+    exec{'extract_sp':
+      command => " \
+\$ErrorActionPreference = 'Stop'; \
+write-output \"username: \$env:username \"; \
+Start-Process '${sppath}' -ArgumentList '/extract:C:\\Puppet-SharePoint\\2013\\Foundation /q' -Wait",
+      provider => 'powershell',
+      onlyif   => "if((test-path '${basepath}\\Puppet-SharePoint\\2013\\Foundation\\setup.exe') -eq \$true){exit 1}",
+      timeout  => '600',
+    }
+  } else {
+      windows_isos{'SPStandard':
+        ensure   => present,
+        isopath  => $sppath,
+        xmlpath  => "${basepath}\\Puppet-SharePoint\\isos.xml",
+      } ->
+      file{"$basepath\\Puppet-SharePoint\\spcopy.ps1":
+        content => template('windows_sharepoint/prepsp-server.erb'),
+      } ->
+      exec{'extract SP':
+        command => "$basepath\\Puppet-SharePoint\\spcopy.ps1;",
+        provider => 'powershell',
+        onlyif   => "if((test-path '${basepath}\\Puppet-SharePoint\\2013\\SharePoint\\setup.exe') -eq \$true){exit 1}",
+        timeout  => '600',
+      }
+  }
+}

--- a/templates/autospinstaller.erb
+++ b/templates/autospinstaller.erb
@@ -109,12 +109,14 @@ $sitecolowner = "<%= @sitecolowner%>";
 ### Part set XML info
 
 ## Install
-$xml.Configuration.Install.PIDKey = $key;
-if($spversion -ne 'Enterprise'){
-$xml.Configuration.Install.SKU = 'Standard';
-}else{
-$xml.Configuration.Install.SKU = 'Enterprise';
+
+if($spversion -eq "Foundation") {
+  $child = $xml.Configuration.Install.SelectSingleNode("PIDKey")
+  $xml.Configuration.Install.RemoveChild($child)
+} else {
+  $xml.Configuration.Install.PIDKey = $key;
 }
+$xml.Configuration.Install.SKU = $spversion;
 $xml.Configuration.Install.OfflineInstall = $offline;
 $xml.Configuration.Install.AutoAdminLogon.Enable = $autoadminlogon;
 $xml.Configuration.Install.AutoAdminLogon.Password = $setupaccountpassword;
@@ -123,15 +125,17 @@ $xml.Configuration.Install.Disable.LoopbackCheck = $disableloopbackcheck;
 $xml.Configuration.Install.Disable.UnusedServices = $disableunusedservices;
 $xml.Configuration.Install.Disable.IEEnhancedSecurity = $disableieenhancedsecurity;
 $xml.Configuration.Install.Disable.CertificateRevocationListCheck = $disablecertificaterevocationlistcheck;
+# $xml.Configuration.Install.RemoteInstall.Enable = $false;
 
 ## Farm
 $xml.Configuration.Farm.Passphrase = $passphrase;
-$xml.Configuration.Farm.Account.Username = "$env:userdomain\" + $spfarmaccount;
+$xml.Configuration.Farm.Account.Username = $spfarmaccount;
 if($spfarmpassword -eq $null -or $spfarmpassword -eq ""){
   $xml.Configuration.Farm.Account.Password = Get-Password -account $spfarmaccount -userxml $userxml;
 }else{
   $xml.Configuration.Farm.Account.Password = $spfarmpassword;
 }
+
 $xml.Configuration.Farm.CentralAdmin.Provision = $centraladminprovision;
 $xml.Configuration.Farm.CentralAdmin.Database = $centraladmindatabase;
 $xml.Configuration.Farm.CentralAdmin.Port = $centraladminport;
@@ -152,28 +156,28 @@ $xml.Configuration.Farm.Services.FoundationWebApplication.Start = $foundationweb
 #managed account
 foreach($manageaccount in $xml.Configuration.Farm.ManagedAccounts.ManagedAccount){
   if($manageaccount.CommonName -eq "spservice"){
-    $manageaccount.Username = "$env:userdomain\" + $spservicesaccount;
+    $manageaccount.Username = $spservicesaccount;
     if($spservicespassword -eq $null -or $spservicespassword -eq ""){
       $manageaccount.Password = Get-Password -account $spservicesaccount -userxml $userxml;
     }else{
       $manageaccount.Password = $spservicespassword;
     }
   }elseif($manageaccount.CommonName -eq "Portal"){
-    $manageaccount.Username = "$env:userdomain\" + $spapppoolaccount;
+    $manageaccount.Username = $spapppoolaccount;
     if($spapppoolpassword -eq $null -or $spapppoolpassword -eq ""){
       $manageaccount.Password = Get-Password -account $spapppoolaccount -userxml $userxml;
     }else{
       $manageaccount.Password = $spapppoolpassword;
     }
   }elseif($manageaccount.CommonName -eq "SearchService"){
-    $manageaccount.Username = "$env:userdomain\" + $spsearchaccount;
+    $manageaccount.Username = $spsearchaccount;
     if($spsearchpassword -eq $null -or $spsearchpassword -eq ""){
       $manageaccount.Password = Get-Password -account $spsearchaccount -userxml $userxml;
     }else{
       $manageaccount.Password = $spsearchpassword;
     }
   }elseif($manageaccount.CommonName -eq "MySiteHost"){
-    $manageaccount.Username = "$env:userdomain\" + $spusrprfaccount;
+    $manageaccount.Username = $spusrprfaccount;
     if($spusrprfpassword -eq $null -or $spusrprfpassword -eq ""){
       $manageaccount.Password = Get-Password -account $spusrprfaccount -userxml $userxml;
     }else{
@@ -181,8 +185,8 @@ foreach($manageaccount in $xml.Configuration.Farm.ManagedAccounts.ManagedAccount
     }
   }
 }
-$xml.Configuration.Farm.ObjectCacheAccounts.SuperUser = "$env:userdomain\" + $spsuperuseraccount;
-$xml.Configuration.Farm.ObjectCacheAccounts.SuperReader = "$env:userdomain\" + $spsuperreaderaccount
+$xml.Configuration.Farm.ObjectCacheAccounts.SuperUser = $spsuperuseraccount;
+$xml.Configuration.Farm.ObjectCacheAccounts.SuperReader = $spsuperreaderaccount
 
 #Logging
 $xml.Configuration.Farm.Logging.IISLogs.Compress = $logcompress;
@@ -208,20 +212,20 @@ $xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCol
 $xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCollection.Time24 = $sitecoltime24;
 $xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCollection.LCID = $sitecollcid;
 $xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCollection.Locale = $sitecollocale;
-$xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCollection.Owner = "$env:userdomain\"+$sitecolowner;
+$xml.Configuration.WebApplications.WebApplication.Get(0).SiteCollections.SiteCollection.Owner = $sitecolowner;
 
 ##switch all alias to the one defined
-$xml.Configuration.ServiceApps.ManagedMetadataServiceApp.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.UserProfileServiceApp.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.StateService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.SPUsageService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.SecureStoreService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.AppManagementService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.SubscriptionSettingsService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.WebAnalyticsService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.MachineTranslationService.Database.DBServer = $dbserver;
-$xml.Configuration.ServiceApps.BusinessDataConnectivity.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.ManagedMetadataServiceApp.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.UserProfileServiceApp.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.StateService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.SPUsageService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.SecureStoreService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.AppManagementService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.SubscriptionSettingsService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.WebAnalyticsService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.MachineTranslationService.Database.DBServer = $dbserver;
+#$xml.Configuration.ServiceApps.BusinessDataConnectivity.Database.DBServer = $dbserver;
 
 if($spversion -eq 'Foundation'){
 	$xml.Configuration.ServiceApps.EnterpriseSearchService.Provision = "false";
@@ -233,7 +237,7 @@ $xml.Configuration.ServiceApps.ManagedMetadataServiceApp.Provision = $computerna
 $xml.Configuration.ServiceApps.EnterpriseSearchService.Provision = $computername;
 $xml.Configuration.ServiceApps.UserProfileServiceApp.Provision = $computername;
 	$xml.Configuration.ServiceApps.WorkManagementService.Provision = $computername;
-$xml.Configuration.ServiceApps.UserProfileServiceApp.SyncConnectionAccount = "$env:userdomain\"+$spsyncaccount;
+$xml.Configuration.ServiceApps.UserProfileServiceApp.SyncConnectionAccount = $spsyncaccount;
 $xml.Configuration.ServiceApps.UserProfileServiceApp.MySiteHostLocation = $mysitehost;
 $xml.Configuration.ServiceApps.UserProfileServiceApp.MySiteManagedPath = $mysitemanagedpath;
 
@@ -262,7 +266,7 @@ $xml.Configuration.ServiceApps.BusinessDataConnectivity.Provision = $computernam
 if($spversion -eq 'Enterprise'){
 if($spexcelaccount -ne "" -or $spexcelaccount -ne $null){
 	$xml.Configuration.EnterpriseServiceApps.ExcelServices.Provision = "true";
-	$xml.Configuration.EnterpriseServiceApps.ExcelServices.UnattendedIDUser = "$env:userdomain\"+$spexcelaccount;
+	$xml.Configuration.EnterpriseServiceApps.ExcelServices.UnattendedIDUser = $spexcelaccount;
 	if($spexcelpassword -eq $null -or $spexcelpassword -eq ""){
 	  $xml.Configuration.EnterpriseServiceApps.ExcelServices.UnattendedIDPassword = Get-Password -account $spexcelaccount -userxml $userxml;
 	}else{
@@ -272,13 +276,15 @@ if($spexcelaccount -ne "" -or $spexcelaccount -ne $null){
 }
 }
 ##switch user for crawl
-$xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.ContentAccessAccount = "$env:userdomain\"+$spcrawlaccount;
+$xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.ContentAccessAccount = $spcrawlaccount;
 if($spcrawlpassword -eq $null -or $spcrawlpassword -eq ""){
   $xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.ContentAccessAccountPassword = Get-Password -account $spcrawlaccount -userxml $userxml;
 }else{
   $xml.Configuration.ServiceApps.EnterpriseSearchService.EnterpriseSearchServiceApplications.EnterpriseSearchServiceApplication.ContentAccessAccountPassword = $spcrawlpassword;
 }
-if((Test-Path "$path/xmlgenerated") -eq $false){New-Item -Name "xmlgenerated" -Path $path -type file;}
 
-
+$msg = "Saving file at: """ + $xmlpath + """.";
+write-output $msg;
 $xml.save($xmlpath);
+
+if((Test-Path "$path/xmlgenerated") -eq $false){New-Item -Name "xmlgenerated" -Path $path -type file;}


### PR DESCRIPTION
manifests/init.pp

+ Added setup_account_username option.
+ Added class anchors.
+ Added class windows_sharepoint::stage_bin.


manifests/install.pp

+ Changed defaults for dbalias, dbaliasport, dbaliasinstance, dbserver.
+ Added param setup_account_username.
+ Refactored exec commands for deduplication and to workaround powershell exec provider return code issues.
+ Added code to call setacl.exe in order to workaround SharePoint 2013 installer bug.
+ Added code to manage AutoSpInstaller reboots.


manifests/prepsp.pp
+ Refactored for readability.


templates/autospinstaller.erb

+ Excluded some nodes when installing Sharepoint Foundation.
+ Removed automatic domain prepending to usernames to support cross-domain installs.


notes:

+ Script assumes that modified AutoSpInstaller is extracted to $basepath/Puppet-Sharepoint. Modified version is available here: https://github.com/jpuskar/AutoSpInstaller .
+ Script assumes that setacl.exe is available in the system path.

